### PR TITLE
Consolidate crl management and test cleanup.

### DIFF
--- a/ovpn/client_config.py
+++ b/ovpn/client_config.py
@@ -1,6 +1,5 @@
 """Output client config ovpn file contents for an existing user"""
 import os
-import shutil
 from ovpn_util import load_config, read_file, read_x509, ValidationException
 from pki_config import PkiConfig
 
@@ -43,7 +42,3 @@ class ClientConfig:
 
         # revoke client and re-generate the CRL
         self.pki_config.revoke_client(name)
-
-        # copy updated CRL from PKI dir to the VPN dir and make readable by everyone
-        shutil.copy(os.path.join(self.pki_dir, "crl.pem"), self.vpn_dir)
-        os.chmod(os.path.join(self.vpn_dir, "crl.pem"), 0o644)

--- a/ovpn/ovpn_run
+++ b/ovpn/ovpn_run
@@ -23,13 +23,6 @@ for i in "${OVPN_ROUTES[@]}"; do
     }
 done
 
-# Use a copy of crl.pem as the CRL Needs to be readable by the user/group
-# OpenVPN is running as.
-if [ "$EASYRSA_PKI/crl.pem" -nt "$OPENVPN/crl.pem" ]; then
-    cp -f "$EASYRSA_PKI/crl.pem" "$OPENVPN/crl.pem"
-    chmod 644 "$OPENVPN/crl.pem"
-fi
-
 ARGS=("--config" "$OPENVPN/server.conf")
 echo "Running 'openvpn ${ARGS[@]}'"
 exec openvpn ${ARGS[@]}

--- a/ovpn/pki_config.py
+++ b/ovpn/pki_config.py
@@ -1,5 +1,6 @@
 """Manage the PKI config for the VPN server"""
 import os
+import shutil
 from subprocess import Popen, PIPE
 from ovpn_util import load_config, render_template, write_file, ValidationException
 
@@ -54,6 +55,11 @@ class PkiConfig:
     def gen_crl(self):
         """Generate the CRL for the server"""
         self.exec_pki("gen-crl")
+
+        # copy updated CRL from PKI dir to the VPN dir and make readable by everyone so the OpenVPN process
+        # can read it
+        shutil.copy(os.path.join(self.pki_dir, "crl.pem"), self.vpn_dir)
+        os.chmod(os.path.join(self.vpn_dir, "crl.pem"), 0o644)
 
     def ensure_init(self):
         """Ensure that the PKI directory exists"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Location for pytest fixtures."""
+import os
+import pytest
+from tests import test_dir, temp_dir, rm_tree
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(request):
+    """Run cleanup logic at end of all tests"""
+    def clear_temp():
+        """"Clear CRL from test directory as it changes every time we run"""
+        rm_tree(temp_dir)
+
+    def remove_crl():
+        """"Clear CRL from test directory as it changes every time we run"""
+        os.remove(os.path.join(test_dir, "crl.pem"))
+
+    request.addfinalizer(clear_temp)
+    request.addfinalizer(remove_crl)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,5 +36,3 @@ def test_revoke_client_config():
     client.revoke("test")
     assert not os.path.exists(os.path.join(temp_pki_dir, "private/test.key"))
     assert os.path.exists(os.path.join(test_dir, "crl.pem"))
-    # Cleanup
-    os.remove(os.path.join(test_dir, "crl.pem"))

--- a/tests/test_pki.py
+++ b/tests/test_pki.py
@@ -16,6 +16,7 @@ def test_pki_config():
     config = PkiConfig(test_dir, temp_pki_dir, PKI_BIN_DIR)
     config.init()
     assert read_file(os.path.join(test_dir, "easyrsa-vars")) == read_expected_output("easyrsa-vars")
+    assert read_file(os.path.join(test_dir, "crl.pem")) == read_file(os.path.join(temp_pki_dir, "crl.pem"))
 
 def test_pki_config_client():
     """Verify we can generate a client config."""


### PR DESCRIPTION
Consolidate crl.pem logic into PkiConfig method. This will copy the file and set permissions appropriately when it is created or modified.