### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the branch and commit hash

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -30,7 +30,7 @@ jobs:
           target: test
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,7 +28,7 @@ jobs:
           target: test
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
Update docker/login-action and docker/metadata-action to latest versions.

This resolves some of the build output warnings such as:
```
build-and-push-image
The following actions uses node12 which is deprecated and will be forced to run on node16: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9, docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

build-and-push-image
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

...
```